### PR TITLE
ISSUE-32: Fulltext and Plaintext, best friends.

### DIFF
--- a/src/Annotation/StrawberryRunnersPostProcessor.php
+++ b/src/Annotation/StrawberryRunnersPostProcessor.php
@@ -57,10 +57,10 @@ class StrawberryRunnersPostProcessor extends Plugin {
   /**
    * The Object property that contains the additional data needed by the Processor ::run method
    *
-   * @var string $input_arguments;
+   * @var string|NULL $input_argument;
    *
    */
-  public $input_arguments;
+  public $input_argument;
 
   /**
    * Processing stage: can be Entity PreSave or PostSave

--- a/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
@@ -210,9 +210,9 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
         $input_property = $processor_instance->getPluginDefinition()['input_property'];
         $input_argument = $processor_instance->getPluginDefinition()['input_argument'];
 
-        // @TODO If argument is not here, do we return??
+        // If argument is not there we will assume there is a mistake and its
+        // a single one.
         $data->{$input_argument} = isset($data->{$input_argument}) ? $data->{$input_argument} : 1;
-
         if (is_a($entity, TranslatableInterface::class)) {
           $translations = $entity->getTranslationLanguages();
           foreach ($translations as $translation_id => $translation) {
@@ -250,7 +250,9 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
           $toindex = new stdClass();
           $toindex->fulltext = $io->output->searchapi['fulltext'];
           $toindex->plaintext = $io->output->searchapi['plaintext'];
-          $toindex->sequence_total = $io->output->sequence_total;
+          // $siblings will be the amount of total children processors that were
+          // enqueued for a single Processor chain.
+          $toindex->sequence_total = !empty($data->siblings) ? $data->siblings : 1;
           $toindex->checksum = $data->metadata['checksum'];
 
           $datasource_id = 'strawberryfield_flavor_datasource';
@@ -290,7 +292,6 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
       }
     }
     else {
-      // This will not
       $io = $this->invokeProcessor($processor_instance, $data);
     }
     // Means we got a file back from the processor
@@ -332,6 +333,8 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
         $childdata->{$input_property} = $input_property_value;
         $childdata->plugin_config_entity_id = $postprocessor_config_entity->id();
         $input_argument_value = isset($io->output->plugin) && isset($io->output->plugin[$input_argument]) ? $io->output->plugin[$input_argument] : $data->{$input_argument};
+        // This is a must: Solr indexing requires a list of sequences. A single one
+        // will not be enqueued.
         if (is_array($input_argument_value)) {
           foreach ($input_argument_value as $value) {
             // Here is the catch.
@@ -339,6 +342,9 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
             // Input Properties matching always need to be one
             if (!is_array($value)) {
               $childdata->{$input_argument} = $value;
+              // The count will always be relative to this call
+              // Means count of how many children are being called.
+              $childdata->siblings = count($input_argument_value);
               Drupal::queue('strawberryrunners_process_background', TRUE)
                 ->createItem($childdata);
             }
@@ -363,9 +369,9 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
   protected function getProcessorPlugin($plugin_config_entity_id) {
     // Get extractor configuration.
     /* @var $plugin_config_entity \Drupal\strawberry_runners\Entity\strawberryRunnerPostprocessorEntityInterface */
-    $plugin_config_entity = $this->entityTypeManager->getStorage(
-      'strawberry_runners_postprocessor'
-    )->load($plugin_config_entity_id);
+    $plugin_config_entity = $this->entityTypeManager
+      ->getStorage('strawberry_runners_postprocessor')
+      ->load($plugin_config_entity_id);
 
     if ($plugin_config_entity->isActive()) {
       $entity_id = $plugin_config_entity->id();
@@ -470,17 +476,13 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
         'saa_field_file_news',
         'saa_field_file_page'
       ]);*/
-      //$parse_mode = $this->parseModeManager->createInstance('direct');
       $parse_mode = $this->parseModeManager->createInstance('terms');
       $query->setParseMode($parse_mode);
-      // $parse_mode->setConjunction('OR');
-      // $query->keys($search);
       $query->sort('search_api_relevance', 'DESC');
 
       $query->addCondition('search_api_id', 'strawberryfield_flavor_datasource/' . $key)
         ->addCondition('search_api_datasource', 'strawberryfield_flavor_datasource')
         ->addCondition('checksum', $checksum);
-      //$query = $query->addCondition('ss_checksum', $checksum);
       // If we allow processing here Drupal adds Content Access Check
       // That does not match our Data Source \Drupal\search_api\Plugin\search_api\processor\ContentAccess
       // we get this filter (see 2nd)
@@ -620,14 +622,13 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
         $field_content['flv:' . $data->plugin_config_entity_id] = array_unique(
           $field_content['flv:' . $data->plugin_config_entity_id]
         );
-        $field_content[$jsonkey][$uniqueid]['flv:'
-        . $data->plugin_config_entity_id]
-          = $this->addActivityStream($data->plugin_config_entity_id);
+        $field_content[$jsonkey][$uniqueid]['flv:' . $data->plugin_config_entity_id] = $this->addActivityStream($data->plugin_config_entity_id);
         $itemfield->setMainValueFromArray($field_content);
         // Should we check decide on this? Safer is a new revision, but also an overhead
         // $entity->setNewRevision(FALSE);
         $entity->save();
-      } catch (Exception $exception) {
+      }
+      catch (Exception $exception) {
         $message_params = [
           '@file_id' => $data->fid,
           '@entity_id' => $data->nid,
@@ -654,7 +655,6 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
       );
       unlink($io->output->file);
     }
-
   }
 
   protected function addActivityStream($name = NULL) {

--- a/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
@@ -204,7 +204,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
       try {
         // Get which indexes have our StrawberryfieldFlavorDatasource enabled!
         $indexes = StrawberryfieldFlavorDatasource::getValidIndexes();
-        $keyvalue_collection = 'Strawberryfield_flavor_datasource_temp';
+        $keyvalue_collection = StrawberryfieldFlavorDatasource::SBFL_KEY_COLLECTION;
         $item_ids = [];
         $inindex = 1;
         $input_property = $processor_instance->getPluginDefinition()['input_property'];

--- a/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
@@ -248,7 +248,9 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
 
           // Check if $io->output exists?
           $toindex = new stdClass();
-          $toindex->fulltext = $io->output->searchapi;
+          $toindex->fulltext = $io->output->searchapi['fulltext'];
+          $toindex->plaintext = $io->output->searchapi['plaintext'];
+          $toindex->sequence_total = $io->output->sequence_total;
           $toindex->checksum = $data->metadata['checksum'];
 
           $datasource_id = 'strawberryfield_flavor_datasource';

--- a/src/Plugin/StrawberryRunnersPostProcessor/JsonFileSequencePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/JsonFileSequencePostProcessor.php
@@ -138,28 +138,31 @@ class JsonFileSequencePostProcessor extends StrawberryRunnersPostProcessorPlugin
     $file_uuid = isset($io->input->metadata['dr:uuid']) ? $io->input->metadata['dr:uuid'] : NULL;
     $node_uuid = isset($io->input->nuuid) ? $io->input->nuuid : NULL;
     $config = $this->getConfiguration();
-    $page_number = [];
+    $sequence_number = [];
     if (isset($io->input->{$input_property}) && $file_uuid && $node_uuid) {
       // To be used by miniOCR as id in the form of {nodeuuid}/canvas/{fileuuid}/p{pagenumber}
       $io->output = $io->input;
       // Now check if there is an "flv:identify" and iterate over each one.
       if (isset($io->input->metadata['flv:identify']) && count($io->input->metadata['flv:identify']) > 0) {
         foreach ($io->input->metadata['flv:identify'] as $key => $sequence) {
-          $page_number[] = $key;
+          $sequence_number[] = $key;
         }
       }
       elseif (isset($io->input->metadata['flv:pdfinfo']) && count($io->input->metadata['flv:pdfinfo']) > 0) {
         foreach ($io->input->metadata['flv:pdfinfo'] as $key => $sequence) {
-          $page_number[] = $key;
+          $sequence_number[] = $key;
         }
       }
       // At least give it one page. (Should we?)
-      if (empty($page_number)) {
-        $page_number[] = 1;
+      if (empty($sequence_number)) {
+        $sequence_number[] = 1;
       }
 
       $output = new \stdClass();
-      $output->plugin = ['page_number' => $page_number];
+      $output->plugin = [
+        'sequence_number' => $sequence_number,
+        'sequence_total' => count($sequence_number),
+      ];
       $io->output = $output;
     }
     else {

--- a/src/Plugin/StrawberryRunnersPostProcessor/JsonFileSequencePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/JsonFileSequencePostProcessor.php
@@ -161,7 +161,6 @@ class JsonFileSequencePostProcessor extends StrawberryRunnersPostProcessorPlugin
       $output = new \stdClass();
       $output->plugin = [
         'sequence_number' => $sequence_number,
-        'sequence_total' => count($sequence_number),
       ];
       $io->output = $output;
     }

--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -349,9 +349,7 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
           $io->output = $output;
         }
       }
-      // Lastly pass back to output the sequence_total property
-      $sequence_total = isset($io->input->sequence_total) ? $io->input->sequence_total : $sequence_number;
-      $io->output->sequence_total  = $sequence_total;
+      // Lastly plain text version of the XML.
       $io->output->searchapi['plaintext'] = isset($output->searchapi['fulltext']) ? strip_tags(str_replace("<l>", PHP_EOL . "<l> ", $output->searchapi['fulltext'])) : '';
     }
     else {


### PR DESCRIPTION
See #32

This adds plaintext, makes $output->searchapi an array structure instead of a single property, passes back the complete count of sequences and renames "pages" to "sequences" because pages was a long shot and too specific for books. so yes! Requires https://github.com/esmero/strawberryfield/pull/168 to work!

@giancarlobi feel free to test. Again, needs 168 (which is ready enough now)

