### PR TITLE
ISSUE-54: Fixes broken NLPClient and adds FastText as default

### DIFF
--- a/src/Plugin/StrawberryRunnersPostProcessor/WaczPagesSequencePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/WaczPagesSequencePostProcessor.php
@@ -172,7 +172,7 @@ class WaczPagesSequencePostProcessor extends StrawberryRunnersPostProcessorPlugi
         $j = 0;
         $fp = $z->getStream('pages/pages.jsonl');
         if ($fp) {
-          while (($buffer = fgets($fp, 32767)) !== FALSE) {
+          while (($buffer = fgets($fp)) !== FALSE) {
             // First row in a jsonl will be the headers, we do not need this one.
             if ($i == 0) {
               $i++;
@@ -193,7 +193,7 @@ class WaczPagesSequencePostProcessor extends StrawberryRunnersPostProcessorPlugi
         }
         $fp_extra = $z->getStream('pages/extraPages.jsonl');
         if ($fp_extra) {
-          while (($buffer = fgets($fp_extra, 32767)) !== FALSE) {
+          while (($buffer = fgets($fp_extra)) !== FALSE) {
             // First row in a jsonl will be the headers, we do not need this one.
             if ($j == 0) {
               $j++;
@@ -209,12 +209,13 @@ class WaczPagesSequencePostProcessor extends StrawberryRunnersPostProcessorPlugi
           fclose($fp_extra);
         }
         else {
-          // Opening the ZIP file failed.
-          error_log('No Pages found to extract');
+          error_log('No Extra Pages found to extract');
         }
     }
-
-
+      else {
+        // Opening the ZIP file failed.
+        error_log('Could not open the ZIP file');
+      }
       $output->plugin = [
         'sequence_number' => $sequence_number,
         'plugin_metadata' => $sequence_data,

--- a/src/Plugin/StrawberryRunnersPostProcessor/WebPageTextPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/WebPageTextPostProcessor.php
@@ -7,7 +7,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\strawberryfield\Plugin\search_api\datasource\StrawberryfieldFlavorDatasource;
 use Drupal\strawberry_runners\Annotation\StrawberryRunnersPostProcessor;
 use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginInterface;
-use Web64\Nlp\NlpClient;
+use Drupal\strawberry_runners\Web64\Nlp\NlpClient;
 
 /**
  *
@@ -192,14 +192,26 @@ class WebPageTextPostProcessor extends StrawberryRunnersPostProcessorPluginBase 
           $nlp = new NlpClient($config['nlp_url']);
           if ($nlp) {
             $languages_enabled = [];
-            $detected_lang = $nlp->language($page_text) ?? NULL;
+            $capabilities = $nlp->get_call('/status', NULL);
+            $detected_lang = NULL;
+            //@TODO Should cache this too. Or deprecate ::language for 0.5.0
+            if ($capabilities
+              && is_array($capabilities)
+              && is_array($capabilities['web64']['endpoints'])
+              && in_array('/fasttext', $capabilities['web64']['endpoints'])) {
+              $detected_lang = $nlp->fasttext($page_text);
+              $detected_lang = is_array($detected_lang) && isset($detected_lang['language']) ? $detected_lang['language'] : $detected_lang;
+            }
+            // Either Capabilities are not present for FastText of we had an issue.
+            if ($detected_lang == NULL) {
+              $detected_lang = $nlp->language($page_text) ?? NULL;
+            }
             $cache_id = "strawberry_runners:postprocessor:".$this->getPluginId();
             $cached = $this->cacheBackend->get($cache_id);
             if ($cached) {
               $languages_enabled = $cached->data;
             }
             else {
-              $capabilities = $nlp->get_call('/status', NULL);
               if ($capabilities && is_array($capabilities) && isset($capabilities['polyglot_lang_models']) && is_array($capabilities['polyglot_lang_models'])) {
                 $languages_enabled = array_keys($capabilities['polyglot_lang_models']);
                 $languages_enabled = array_map(function ($languages_enabled) {
@@ -252,6 +264,18 @@ class WebPageTextPostProcessor extends StrawberryRunnersPostProcessorPluginBase 
               }
             }
             $output->searchapi['nlplang'] = [$detected_lang];
+            foreach (['where','who', 'metadata'] as $nlp_key) {
+              if (isset($output->searchapi[$nlp_key])
+                && is_array(
+                  $output->searchapi[$nlp_key]
+                )
+              ) {
+                $output->searchapi[$nlp_key] = preg_grep(
+                  "/^[\p{L}|\p{N}\s+]+[\p{L}|\p{N}\s\-'+]+[\p{L}|\p{N}\s+]+$/u",
+                  $output->searchapi[$nlp_key]
+                );
+              }
+            }
           }
           else {
             $this->logger->warning('NLP64 server @nlp_url could not be queried. Skipping NLP.',
@@ -270,7 +294,7 @@ class WebPageTextPostProcessor extends StrawberryRunnersPostProcessorPluginBase 
         $output->plugin = $output->searchapi;
       }
       else {
-        throw new \Exception("WebPage Text was not a valid JSON");
+        throw new \Exception("WebPage Text was not a valid JSON.");
       }
     }
     $io->output = $output;

--- a/src/Web64/Nlp/NlpClient.php
+++ b/src/Web64/Nlp/NlpClient.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Drupal\strawberry_runners\Web64\Nlp;
+
+use Web64\Nlp\NlpClient as Web64NlpClient;
+
+class NlpClient extends Web64NlpClient {
+
+  const MAX_RETRY_HOST = 3;
+
+  /**
+   *  Get language code for text
+   *
+   * @param     $text
+   * @param int $predictions
+   *
+   * @return mixed|null
+   */
+  public function fasttext($text, $predictions = 1) {
+    //Predictions at least 1 are required if POSTING. GET is more forgiving
+    //Also. We need to URL encode upfront here.
+    $data = $this->post_call(
+      '/fasttext', ['text' => rawurlencode($text), 'predictions' => $predictions]
+    );
+    if (isset($data['fasttext']) && isset($data['fasttext']['language'])) {
+      return $data['fasttext'];
+    }
+    return NULL;
+  }
+
+  public function get_call($path, $params, $retry = 0) {
+    $url = $this->api_url . $path;
+
+    $retry++;
+
+    if (!empty($params)) {
+      $url .= '?' . http_build_query($params);
+    }
+
+    $result = @file_get_contents($url, FALSE);
+
+    $response = isset($http_response_header) && isset($http_response_header[0])
+      ? $this->isValidResponse($http_response_header[0]) : FALSE;
+    if ($response && !empty($result)) {
+      return json_decode($result, 1);
+    }
+    else {
+      if ($retry >= static::MAX_RETRY_HOST) {
+        return NULL;
+      }
+      $this->chooseHost();
+      return $this->post_call($path, $params, $retry);
+    }
+  }
+
+  public function post_call($path, $params, $retry = 0) {
+    $url = $this->api_url . $path;
+    $retry++;
+    if ($retry > static::MAX_RETRY_HOST) {
+      return NULL;
+    }
+    $opts = [
+      'http' =>
+        [
+          'method'  => 'POST',
+          'header'  => 'Content-type: application/x-www-form-urlencoded',
+          'content' => http_build_query($params),
+        ],
+    ];
+    $context = stream_context_create($opts);
+    $result = @file_get_contents($url, FALSE, $context);
+    $response = isset($http_response_header) && isset($http_response_header[0])
+      ? $this->isValidResponse($http_response_header[0]) : FALSE;
+    if ($response && !empty($result)) {
+      return json_decode($result, 1);
+    }
+    else {
+      if ($retry >= static::MAX_RETRY_HOST) {
+        return NULL;
+      }
+      $this->chooseHost();
+      return $this->post_call($path, $params, $retry);
+    }
+  }
+
+  // find working host
+  protected function chooseHost() {
+    $random_a = $this->api_hosts;
+    shuffle($random_a); // pick random host
+    foreach ($random_a as $api_url) {
+      $content = @file_get_contents($api_url);
+      if (!empty($content)) {
+        $this->api_url = $api_url;
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Checks if a Python Webserver Response String is valid for us
+   *
+   * @param $response_string
+   *   HTTP/1.0 THECODE SOME WORDS
+   *
+   * @return bool
+   */
+  protected function isValidResponse($response_string) {
+    $response_code_split = explode(" ", $response_string);
+    if (isset($response_code_split[1])) {
+      $response_code = (int) $response_code_split[1];
+      if ($response_code >= 200 && $response_code <= 299) {
+        return TRUE;
+      }
+    }
+    return FALSE;
+  }
+}


### PR DESCRIPTION
See #54 

This also makes sure FastText is the default method for both WebPage Extraction and OCR.
Adds a naive Regular Expression filter for NLP but more needs to be done. E.g a larger website generates more than 700 agents. Which one are relevant?

This is the regular expression:

```PHP
$data_to_test = ["Düsseldorf", "إسرائيل", "сейчас", "γνωρίζωἀπὸ","საერთა შორისო","---hola---", "'", "hola", "", "ሰማይ አይታረስ", "O'Higgins", "4th Of July"];

$data_to_test = preg_grep("/^[\p{L}|\p{N}\s+]+[\p{L}|\p{N}\s\-'+]+[\p{L}|\p{N}\s+]+$/u", $data_to_test);
var_dump($data_to_test);
```

Gives

```Shell
array(9) {
  [0]=>
  string(11) "Düsseldorf"
  [1]=>
  string(14) "إسرائيل"
  [2]=>
  string(12) "сейчас"
  [3]=>
  string(22) "γνωρίζωἀπὸ"
  [4]=>
  string(37) "საერთა შორისო"
  [7]=>
  string(4) "hola"
  [9]=>
  string(25) "ሰማይ አይታረስ"
  [10]=>
  string(9) "O'Higgins"
  [11]=>
  string(11) "4th Of July"
}
````

Tested with polyglot. Spacy with its lack of proper language is a bit "
space.

Thanks to @digitaldogsbody for his work on `fastText` and to @alliomeria for testing/seeing me fail today