### PR TITLE
ISSUE-59 --- Fix fatal error when \Drupal\strawberry_runners\Web64\Nlp\NlpClient::post_call is called with empty params

### DIFF
--- a/src/Web64/Nlp/NlpClient.php
+++ b/src/Web64/Nlp/NlpClient.php
@@ -54,6 +54,10 @@ class NlpClient extends Web64NlpClient {
   }
 
   public function post_call($path, $params, $retry = 0) {
+    // Do not POST without query parameters.
+    if(!is_array($params) || empty($params)) {
+      return NULL;
+    }
     $url = $this->api_url . $path;
     $retry++;
     if ($retry > static::MAX_RETRY_HOST) {


### PR DESCRIPTION
It seems like this is the most solid way to fix this obscure error that only happens if the NLP processor fails to provide a response in get_call, and as a result post_call() is retried with empty params.