### PR TITLE
ISSUE-122 && ISSUE-123: JSON Key File upload config for SBR Processors + Special PDFAlto single BBOX (advanced)

### DIFF
--- a/config/schema/strawberry_runners.schema.yml
+++ b/config/schema/strawberry_runners.schema.yml
@@ -45,6 +45,12 @@ strawberryfield_runners.strawberry_runners_postprocessor.binary:
     mime_type:
       type: string
       label: 'Mimetypes(s) to limit this Processor to'
+    dr_for:
+      type: string
+      label: 'Limit this Processor to files uploaded to certain JSON Key(s)'
+    dr_for_negate:
+      type: string
+      label: 'Reverse the "files uploaded to certain JSON Key(s) limit" by allowing any except those'
     file_limit_type:
       type: string
       label: 'Type of File limit to impose for as:filetype driven input, <=. >= or NULL of disabled'
@@ -98,6 +104,12 @@ strawberryfield_runners.strawberry_runners_postprocessor.ocr:
     mime_type:
       type: string
       label: 'Mimetypes(s) to limit this Processor to'
+    dr_for:
+      type: string
+      label: 'Limit this Processor to files uploaded to certain JSON Key(s)'
+    dr_for_negate:
+      type: string
+      label: 'Reverse the "files uploaded to certain JSON Key(s) limit" by allowing any except those'
     language_default:
       type: string
       label: 'The default language'
@@ -105,6 +117,9 @@ strawberryfield_runners.strawberry_runners_postprocessor.ocr:
     language_key:
       type: bool
       label: 'The JSON key(s) containing the language code in ISO639-3'
+    single_bounding_box_pdfalto:
+      type: bool
+      label: 'If PDFAlto succeeds, remove bounding boxes and generate a full page single "word" miniOCR'
     arguments:
       type: string
       label: 'Any additional argument your executable binary requires'
@@ -191,6 +206,12 @@ strawberryfield_runners.strawberry_runners_postprocessor.filesequence:
     mime_type:
       type: string
       label: 'Mimetypes(s) to limit this Processor to'
+    dr_for:
+      type: string
+      label: 'Limit this Processor to files uploaded to certain JSON Key(s)'
+    dr_for_negate:
+      type: string
+      label: 'Reverse the "files uploaded to certain JSON Key(s) limit" by allowing any except those'
     output_type:
       type: string
       label: 'The expected and desired output of this processor'
@@ -229,6 +250,12 @@ strawberryfield_runners.strawberry_runners_postprocessor.waczpages:
     mime_type:
       type: string
       label: 'Mimetypes(s) to limit this Processor to'
+    dr_for:
+      type: string
+      label: 'Limit this Processor to files uploaded to certain JSON Key(s)'
+    dr_for_negate:
+      type: string
+      label: 'Reverse the "files uploaded to certain JSON Key(s) limit" by allowing any except those'
     output_type:
       type: string
       label: 'The expected and desired output of this processor'
@@ -267,6 +294,124 @@ strawberryfield_runners.strawberry_runners_postprocessor.webpage:
     mime_type:
       type: string
       label: 'Mimetypes(s) to limit this Processor to'
+    dr_for:
+      type: string
+      label: 'Limit this Processor to files uploaded to certain JSON Key(s)'
+    dr_for_negate:
+      type: string
+      label: 'Reverse the "files uploaded to certain JSON Key(s) limit" by allowing any except those'
+    output_type:
+      type: string
+      label: 'The expected and desired output of this processor'
+    output_destination:
+      type: sequence
+      label: 'Where and how the output will be used'
+      sequence:
+        - type: string
+    uses_timeout_executable:
+      type: boolean
+      label: 'if timeout host binary is to be used to control executable binary timeouts'
+    timeout_path:
+      type: string
+      label: 'The path for the timeout binary to execute'
+    timeout:
+      type: integer
+      label: 'Timeout in seconds for this process'
+    weight:
+      type: integer
+      label: 'Order or execution in the global chain'
+    processor_queue_type:
+      type: string
+      label: 'The queue to use for this processor'
+    nlp:
+      type: boolean
+      label: 'If NLP should be triggered for the extracted Text'
+    nlp_url:
+      type: string
+      label: 'The URL of the NLP64 server'
+    nlp_method:
+      type: string
+      label: 'The NLP method, spaCy or Polyglot'
+strawberryfield_runners.strawberry_runners_postprocessor.text:
+  type: config_object
+  label: 'Strawberry Runners Post Processor Config Entity Pure Text specific config'
+  mapping:
+    source_type:
+      type: string
+      label: 'The type of Source Data this Processor works on'
+    ado_type:
+      type: string
+      label: 'DO type(s) to limit this Processor to'
+    jsonkey:
+      type: sequence
+      label: 'The JSON key(s) containing the desired Source File(s)'
+      sequence:
+        - type: string
+    mime_type:
+      type: string
+      label: 'Mimetypes(s) to limit this Processor to'
+    dr_for:
+      type: string
+      label: 'Limit this Processor to files uploaded to certain JSON Key(s)'
+    dr_for_negate:
+      type: string
+      label: 'Reverse the "files uploaded to certain JSON Key(s) limit" by allowing any except those'
+    output_type:
+      type: string
+      label: 'The expected and desired output of this processor'
+    output_destination:
+      type: sequence
+      label: 'Where and how the output will be used'
+      sequence:
+        - type: string
+    uses_timeout_executable:
+      type: boolean
+      label: 'if timeout host binary is to be used to control executable binary timeouts'
+    timeout_path:
+      type: string
+      label: 'The path for the timeout binary to execute'
+    timeout:
+      type: integer
+      label: 'Timeout in seconds for this process'
+    weight:
+      type: integer
+      label: 'Order or execution in the global chain'
+    processor_queue_type:
+      type: string
+      label: 'The queue to use for this processor'
+    nlp:
+      type: boolean
+      label: 'If NLP should be triggered for the extracted Text'
+    nlp_url:
+      type: string
+      label: 'The URL of the NLP64 server'
+    nlp_method:
+      type: string
+      label: 'The NLP method, spaCy or Polyglot'
+strawberryfield_runners.strawberry_runners_postprocessor.subtitle:
+  type: config_object
+  label: 'Strawberry Runners Post Processor Config Entity Subtitles(VTT) specific config'
+  mapping:
+    source_type:
+      type: string
+      label: 'The type of Source Data this Processor works on'
+    ado_type:
+      type: string
+      label: 'DO type(s) to limit this Processor to'
+    jsonkey:
+      type: sequence
+      label: 'The JSON key(s) containing the desired Source File(s)'
+      sequence:
+        - type: string
+    mime_type:
+      type: string
+      label: 'Mimetypes(s) to limit this Processor to'
+    dr_for:
+      type: string
+      label: 'Limit this Processor to files uploaded to certain JSON Key(s)'
+    dr_for_negate:
+      type: string
+      label: 'Reverse the "files uploaded to certain JSON Key(s) limit" by allowing any except those'
     output_type:
       type: string
       label: 'The expected and desired output of this processor'

--- a/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
+++ b/src/Plugin/QueueWorker/AbstractPostProcessorQueueWorker.php
@@ -38,6 +38,7 @@ use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginManager
 use Drupal\strawberryfield\Plugin\search_api\datasource\StrawberryfieldFlavorDatasource;
 use Drupal\search_api\ParseMode\ParseModePluginManager;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Drupal\strawberry_runners\strawberryRunnerUtilityServiceInterface;
 
 abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
 
@@ -107,6 +108,13 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
   protected $eventDispatcher;
 
   /**
+   * The Strawberry Runners Utility Service.
+   *
+   * @var \Drupal\strawberry_runners\strawberryRunnerUtilityServiceInterface
+   */
+  protected $strawberryRunnerUtilityService;
+
+  /**
    * Constructor.
    *
    * @param array $configuration
@@ -119,8 +127,10 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
    * @param \Drupal\Core\KeyValueStore\KeyValueFactoryInterface $key_value
    * @param \Psr\Log\LoggerInterface $logger
    * @param \Drupal\search_api\ParseMode\ParseModePluginManager $parse_mode_manager
+   * @param \Symfony\Component\EventDispatcher\EventDispatcherInterface $event_dispatcher
+   * @param \Drupal\strawberry_runners\strawberryRunnerUtilityServiceInterface $utilityService
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, StrawberryRunnersPostProcessorPluginManager $strawberry_runner_processor_plugin_manager, FileSystemInterface $file_system, StreamWrapperManagerInterface $stream_wrapper_manager, KeyValueFactoryInterface $key_value, LoggerInterface $logger, ParseModePluginManager $parse_mode_manager, EventDispatcherInterface $event_dispatcher) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, StrawberryRunnersPostProcessorPluginManager $strawberry_runner_processor_plugin_manager, FileSystemInterface $file_system, StreamWrapperManagerInterface $stream_wrapper_manager, KeyValueFactoryInterface $key_value, LoggerInterface $logger, ParseModePluginManager $parse_mode_manager, EventDispatcherInterface $event_dispatcher, strawberryRunnerUtilityServiceInterface $utilityService) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->entityTypeManager = $entity_type_manager;
     $this->strawberryRunnerProcessorPluginManager = $strawberry_runner_processor_plugin_manager;
@@ -130,6 +140,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
     $this->logger = $logger;
     $this->parseModeManager = $parse_mode_manager;
     $this->eventDispatcher = $event_dispatcher;
+    $this->strawberryRunnerUtilityService = $utilityService;
   }
 
   /**
@@ -154,7 +165,8 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
       $container->get('keyvalue'),
       $container->get('logger.channel.strawberry_runners'),
       $container->get('plugin.manager.search_api.parse_mode'),
-      $container->get('event_dispatcher')
+      $container->get('event_dispatcher'),
+      $container->get('strawberry_runner.utility')
     );
   }
 
@@ -180,10 +192,6 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
     }
     $processor_config = $processor_instance->getConfiguration();
 
-    // @TODO check on this Diego. This is a bit misleading since it assumes
-    // every processor will work only on Files.
-    // True for now, but eventually we want processors that do only
-    // metadata to metadata.
 
     if (!isset($data->fid) || $data->fid == NULL || !isset($data->nid) || $data->nid == NULL || !is_array($data->metadata)) {
       return;
@@ -257,7 +265,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
         /* @var  $postprocessor_config_entity_chain \Drupal\strawberry_runners\Entity\strawberryRunnerPostprocessorEntity */
         $postprocessor_config_entity_chain = $plugin_info['config_entity'];
         $chains = $postprocessor_config_entity_chain->getPluginconfig(
-          )['output_destination']['plugin'] ?? FALSE;
+        )['output_destination']['plugin'] ?? FALSE;
         $chains = $chains === 'plugin' ? TRUE : FALSE;
         $will_chain_future = $will_chain_future || $chains;
       }
@@ -343,7 +351,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
             $translations = $entity->getTranslationLanguages();
             foreach ($translations as $translation_id => $translation) {
               // checksum and file->uuid apply even if the source is not a local-ized/ensure local file.
-              // But we might want to review this if we plan on indexing JSON RAW/metadata directly as an vector embedding.
+              // But we might want to review this if we plan on indexing JSON RAW/metadata directly as a vector embedding.
               $item_id = $entity->id() . ':' . $sequence_key . ':' . $translation_id . ':' . $file->uuid() . ':' . $data->plugin_config_entity_id;
               // a single 0 as return will force us to reindex.
               $inindex = $inindex * $this->flavorInSolrIndex($item_id, $data->metadata['checksum'], $indexes);
@@ -399,8 +407,8 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
               ]
             );
             if (!isset($io)) {
-              $io = new \stdClass();
-              $io->output = new \stdClass();
+              $io = new stdClass();
+              $io->output = new stdClass();
               $io->output->plugin = [];
             }
             $io->output->plugin['searchapi'] = $processed_data_for_chaining;
@@ -418,7 +426,6 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
                 '@nodeid' => $data->nid,
               ]
             );
-
             $io = $this->invokeProcessor($processor_instance, $data);
             // Check if $io->output exists?
             $toindex = new stdClass();
@@ -464,6 +471,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
               }
               $index->trackItemsInserted($datasource_id, $item_ids);
             }
+
           }
         }
         catch (Exception $exception) {
@@ -471,7 +479,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
         }
       }
       else {
-          $io = $this->invokeProcessor($processor_instance, $data);
+        $io = $this->invokeProcessor($processor_instance, $data);
       }
       // Means we got a file back from the processor
       if ($tobeupdated && isset($io->output->file) && !empty($io->output->file)) {
@@ -496,6 +504,15 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
           }*/
           /* @var  $strawberry_runners_postprocessor_config \Drupal\strawberry_runners\Entity\strawberryRunnerPostprocessorEntity */
           $postprocessor_config_entity = $plugin_info['config_entity'];
+          if (!$this->strawberryRunnerUtilityService->canInvokeSingleProcessor($postprocessor_config_entity->id(), $postprocessor_config_entity->getPluginconfig(), $childdata)) {
+            $this->logger->log(LogLevel::INFO,
+              'Skipping Chained @childplugin BC it does not pass conditions.You can ignore this message',
+              [
+
+                '@childplugin' => $postprocessor_config_entity->id(),
+              ]);
+            continue;
+          }
           $queue_name = $postprocessor_config_entity->getPluginconfig()['processor_queue_type'] ?? 'realtime';
           $queue_name = AbstractPostProcessorQueueWorker::QUEUES[$queue_name] ?? AbstractPostProcessorQueueWorker::QUEUES['realtime'];
           $input_property = $plugin_info['plugin_definition']['input_property'] ?? NULL;
@@ -514,7 +531,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
           // If was not defined by the previous processor try from the main data.
           if ($input_property_value == NULL) {
             $input_property_value_from_plugin = FALSE;
-            $input_property_value = isset($data->{$input_property}) ? $data->{$input_property} : NULL;
+            $input_property_value = $data->{$input_property} ?? NULL;
           }
 
           // If still null means the child is incompatible with the parent. We abort.
@@ -630,7 +647,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
     }
 
     if ($needs_localfile_cleanup && !empty($filelocation)) {
-      $data_cleanup = new \stdClass();
+      $data_cleanup = new stdClass();
       $data_cleanup->filepath_to_clean = [$filelocation];
       $data_cleanup->sbr_cleanup = TRUE;
       if (!$needs_immediate_localfile_cleanup) {
@@ -694,7 +711,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
       ->load($plugin_config_entity_id);
 
     if ($plugin_config_entity->getParent() == '') {
-       return TRUE;
+      return TRUE;
     }
     return FALSE;
   }
@@ -1046,10 +1063,10 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
    * @param string $uri
    *   The URI of the file, e.g. public://directory/file.jpg.
    *
-   * @return mixed
+   * @return string
    *   The real path to the file if it is a local file. A URL otherwise.
    */
-  public function getRealpath(string $uri) {
+  public function getRealpath(string $uri): string {
     $wrapper = $this->streamWrapperManager->getViaUri($uri);
     $scheme = $this->streamWrapperManager->getScheme($uri);
     $local_wrappers = $this->streamWrapperManager->getWrappers(StreamWrapperInterface::LOCAL);
@@ -1098,7 +1115,7 @@ abstract class AbstractPostProcessorQueueWorker extends QueueWorkerBase implemen
     return $pluginid . '_from_' . $uuid . '.' . $destination_extension;
   }
 
-  private function dispatchComposter(\StdClass $data):void {
+  private function dispatchComposter(stdClass $data):void {
     $this->instanceFiles = [];
     foreach($data->filepath_to_clean ?? [] as $instanceFile) {
       $event_type = StrawberryfieldEventType::TEMP_FILE_CREATION;

--- a/src/Plugin/StrawberryRunnersPostProcessor/FrictionlessDataPackagePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/FrictionlessDataPackagePostProcessor.php
@@ -33,7 +33,9 @@ class FrictionlessDataPackagePostProcessor extends StrawberryRunnersPostProcesso
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['application/zip, application\/vnd.datapackage+zip'],
+        'mime_type' => 'application/zip, application\/vnd.datapackage+zip',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'path' => '',
         'arguments' => '',
         'output_type' => 'json',
@@ -94,6 +96,20 @@ class FrictionlessDataPackagePostProcessor extends StrawberryRunnersPostProcesso
       '#description' => $this->t('A single Mimetype type or a coma separed list of mimetypes that qualify to be Processed. Leave empty to apply any file'),
     ];
 
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
+    ];
 
     $element['resource_path'] = [
       '#type' => 'textfield',

--- a/src/Plugin/StrawberryRunnersPostProcessor/JsonFileSequencePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/JsonFileSequencePostProcessor.php
@@ -35,7 +35,9 @@ class JsonFileSequencePostProcessor extends StrawberryRunnersPostProcessorPlugin
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['application/pdf'],
+        'mime_type' => 'application/pdf',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'output_type' => 'json',
         'language_key' => 'language_iso639_3',
         'language_default' => 'eng',
@@ -92,6 +94,21 @@ class JsonFileSequencePostProcessor extends StrawberryRunnersPostProcessorPlugin
       '#title' => $this->t('Mimetypes(s) to limit this Processor to.'),
       '#default_value' => $this->getConfiguration()['mime_type'],
       '#description' => $this->t('A single Mimetype type or a coma separed list of mimetypes that qualify to be Processed. Leave empty to apply any file'),
+    ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
     ];
 
     $element['language_key'] = [
@@ -180,7 +197,7 @@ class JsonFileSequencePostProcessor extends StrawberryRunnersPostProcessorPlugin
         // If not assign the internal file sequence relative to its type (e.g as:image)
         // Final Sequence number is always relative to itself given that on Solr
         // We use the actual file UUID to as part of the ID
-        // e.g default_solr_index-strawberryfield_flavor_datasource/5801:1:en:1e9f687c-e29e-4c23-91ba-655d9c5cdfe6:ocr
+        // e.g. default_solr_index-strawberryfield_flavor_datasource/5801:1:en:1e9f687c-e29e-4c23-91ba-655d9c5cdfe6:ocr
         // For the general ID we will use this number when there are multiple siblings
         // or 1 if the File is a single output
         $sequence_number[] = $io->input->metadata['sequence'];

--- a/src/Plugin/StrawberryRunnersPostProcessor/MLInsightfacePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/MLInsightfacePostProcessor.php
@@ -41,7 +41,7 @@ class MLInsightfacePostProcessor extends abstractMLPostProcessor {
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['image/jpeg'],
+        'mime_type' => 'image/jpeg',
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',

--- a/src/Plugin/StrawberryRunnersPostProcessor/MLMobileNetPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/MLMobileNetPostProcessor.php
@@ -41,7 +41,7 @@ class MLMobileNetPostProcessor extends abstractMLPostProcessor {
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['image/jpeg'],
+        'mime_type' => 'image/jpeg',
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',

--- a/src/Plugin/StrawberryRunnersPostProcessor/MLSentenceTransformertPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/MLSentenceTransformertPostProcessor.php
@@ -41,8 +41,8 @@ class MLSentenceTransformertPostProcessor extends abstractMLPostProcessor {
    */
   public function defaultConfiguration() {
     return [
-        'source_type' => 'asstructure',
-        'mime_type' => ['image/jpeg'],
+        'source_type' => 'json',
+        'mime_type' => '',
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',

--- a/src/Plugin/StrawberryRunnersPostProcessor/MLViTPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/MLViTPostProcessor.php
@@ -41,7 +41,7 @@ class MLViTPostProcessor extends abstractMLPostProcessor {
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['image/jpeg'],
+        'mime_type' => 'image/jpeg',
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',

--- a/src/Plugin/StrawberryRunnersPostProcessor/MLYoloPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/MLYoloPostProcessor.php
@@ -35,7 +35,7 @@ class MLYoloPostProcessor extends abstractMLPostProcessor {
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['image/jpeg'],
+        'mime_type' => 'image/jpeg',
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',

--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -1077,8 +1077,6 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       $miniocr->startElement("p");
       $miniocr->writeAttribute("xml:id", 'sequence_' . $pageid);
       $miniocr->writeAttribute("wh", $pageWidthPx . " " . $pageHeightPx);
-      $miniocr->startElement("p");
-      $miniocr->writeAttribute("xml:id", 'sequence_' . $pageid);
       $page->registerXPathNamespace('ns',
         'http://www.loc.gov/standards/alto/ns-v3#');
       $l = ltrim(sprintf('%.3f', 0) ?? '', 0);

--- a/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/OcrPostProcessor.php
@@ -37,13 +37,16 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['application/pdf'],
+        'mime_type' => 'application/pdf',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'path' => '',
         'path_tesseract' => '',
         'path_pdfalto' => '',
         'arguments' => '',
         'arguments_tesseract' => '',
         'arguments_pdfalto' => '',
+        'single_bounding_box_pdfalto' => FALSE,
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',
@@ -110,6 +113,22 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       '#default_value' => $this->getConfiguration()['mime_type'],
       '#description' => $this->t('A single Mimetype type or a comma separated list of mimetypes that qualify to be Processed. Leave empty to apply any file'),
     ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
+    ];
+
     $element['path'] = [
       '#type' => 'textfield',
       '#title' => $this->t('The system path to the ghostscript (gs) binary that will be executed by this processor.'),
@@ -185,6 +204,14 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       '#description' => t('Any arguments your binary requires to run. Use %file as replacement for the file that is output by the pdfalto binary.'),
       '#required' => FALSE,
     ];
+
+    $element['single_bounding_box_pdfalto'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t("If pdfalto successfully extracts HOCR, ignore the coordinates and generate a single, full page paragraph using the Source Image Coordinates as Bounding box"),
+      '#default_value' => $this->getConfiguration()['single_bounding_box_pdfalto'] ?? FALSE,
+      '#description' => t('This is an advanced option and normally not recommended. Only use if you manually copied a PDF Text layer from a different layout/PDF into the PDF to be processed, and the OCR highlights do not match at all over the images. The new OCR will have a single Bounding box.'),
+    ];
+
 
     $element['output_type'] = [
       '#type' => 'select',
@@ -339,7 +366,15 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       $sequence_number = isset($io->input->{$input_argument}) ? (int) $io->input->{$input_argument} : 1;
       setlocale(LC_CTYPE, 'en_US.UTF-8');
       $execstring_pdfalto = $this->buildExecutableCommand_pdfalto($io);
-
+      // PDFs might not have INFO here at all.
+      // BUT flv:pdfinfo will have for the sequence itself
+      $width = $io->input->metadata['flv:identify'][$sequence_number]['width'] ?? NULL;
+      $height = $io->input->metadata['flv:identify'][$sequence_number]['height'] ?? NULL;
+      // In case identify failed, we can try with flv:exif (e.g JP2s might not pass the identify test)
+      if (!($width && $height)) {
+        $width = $io->input->metadata['flv:exif']['ImageWidth'] ?? NULL;
+        $height = $io->input->metadata['flv:exif']['ImageHeight'] ?? NULL;
+      }
       if ($execstring_pdfalto) {
         $backup_locale = setlocale(LC_CTYPE, '0');
         setlocale(LC_CTYPE, $backup_locale);
@@ -357,8 +392,36 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
             ]);
           throw new \Exception("Could not execute {$execstring_pdfalto} or timed out");
         }
-        if (strpos($proc_output,"TextBlock")!== FALSE) {
-          $miniocr = $this->ALTOtoMiniOCR($proc_output, $sequence_number);
+        $miniocr = NULL;
+        if (strpos($proc_output,"TextBlock") !== FALSE) {
+          if (($config['single_bounding_box_pdfalto'] ?? FALSE) ) {
+            // Super annoying. the $width/height situation on PDFs is a hit an miss.
+            // But also we need one matching the extracted Images
+            // As if this was tesseraact.
+            // We could just run tesseract but use this
+            // but that would be too expensive
+            // So we borrow -r150 or -r300 (defaulting to ghostscripts) internal
+            // And then we use the flv:pdfinfo for this page data. If any
+            // If we can't get a grasp of a width/height then IIIF Content Search API response will fail.
+            if (!$height || !$width) {
+              $ghostscript_resolution = 72;
+              $regex = "/\-r([0-9]+)/";
+              if (preg_match($regex, $config['arguments'], $matches)) {
+                $ghostscript_resolution = $matches[1];
+              }
+              $width = $io->input->metadata['flv:pdfinfo'][$sequence_number]["width"] ?? NULL;
+              $height = $io->input->metadata['flv:pdfinfo'][$sequence_number]["height"] ?? NULL;
+            }
+            if ($width && $height) {
+              $width = ($width * $ghostscript_resolution / 72);
+              $height = ($height * $ghostscript_resolution / 72);
+              $miniocr = $this->ALTOtoMiniOCRSingleWord($proc_output, $width, $height, $sequence_number);
+            }
+          }
+          else {
+            $miniocr = $this->ALTOtoMiniOCR($proc_output, $sequence_number);
+          }
+
           if ($miniocr == NULL) {
             $this->logger->warning("@sbr_processor: ALTO extracted from PDF to miniOCR processing failed for ADO with UUID @node_uuid and File with UUID @file_uuid with sequence number @sequence_id",
               [
@@ -377,14 +440,6 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
       //as the current Image and try to process, if not, run, tesseract
       // @TODO. Ask Allison. If PDFAlto worked out, do we still need to check if there is an attached HOCR?
       // Or does an attached HOCR always wins over PDFtoAlto?
-      $width = $io->input->metadata['flv:identify'][$io->input->{$input_argument}]['width'] ?? NULL;
-      $height = $io->input->metadata['flv:identify'][$io->input->{$input_argument}]['height'] ?? NULL;
-      // In case identify failed, we can try with flv:exif (e.g JP2s might not pass the identify test)
-      if (!($width && $height)) {
-        $width = $io->input->metadata['flv:exif']['ImageWidth'] ?? NULL;
-        $height = $io->input->metadata['flv:exif']['ImageHeight'] ?? NULL;
-      }
-
       if ($width && $height) {
         // Cast them to INT to make sure we are matching exactly
         $width = (int)$width;
@@ -984,6 +1039,87 @@ class OcrPostProcessor extends SystemBinaryPostProcessor {
         $miniocr->endElement();
       }
       $miniocr->endElement();
+    }
+    $miniocr->endElement();
+    $miniocr->endDocument();
+    unset($alto);
+    if ($atleastone_word) {
+      return $miniocr->outputMemory(TRUE);
+    }
+    else {
+      return StrawberryfieldFlavorDatasource::EMPTY_MINIOCR_XML;
+    }
+  }
+
+
+  protected function ALTOtoMiniOCRSingleWord($output, $width, $height, $pageid) {
+    $alto = simplexml_load_string($output);
+    $internalErrors = libxml_use_internal_errors(TRUE);
+    libxml_clear_errors();
+    libxml_use_internal_errors($internalErrors);
+
+    $miniocr = new \XMLWriter();
+    $miniocr->openMemory();
+    $miniocr->startDocument('1.0', 'UTF-8');
+    $miniocr->startElement("ocr");
+    $atleastone_word = FALSE;
+
+    if (!$alto) {
+      return NULL;
+    }
+    foreach ($alto->Layout->children() as $page) {
+      $pageWidthPts = (float) $width;
+      $pageHeightPts = (float) $height;
+      // To check if conversion is ok px = pts / 72 * 300 (dpi)
+      //It seems that pdfalto output is in points while tesseract alto is in pixel
+      $pageWidthPx = sprintf('%.0f', $pageWidthPts);
+      $pageHeightPx = sprintf('%.0f', $pageHeightPts);
+      $miniocr->startElement("p");
+      $miniocr->writeAttribute("xml:id", 'sequence_' . $pageid);
+      $miniocr->writeAttribute("wh", $pageWidthPx . " " . $pageHeightPx);
+      $miniocr->startElement("p");
+      $miniocr->writeAttribute("xml:id", 'sequence_' . $pageid);
+      $page->registerXPathNamespace('ns',
+        'http://www.loc.gov/standards/alto/ns-v3#');
+      $l = ltrim(sprintf('%.3f', 0) ?? '', 0);
+      $t = ltrim(sprintf('%.3f', 0) ?? '', 0);
+      $w = ltrim(sprintf('%.3f', 1) ?? '', 0);
+      $h = ltrim(sprintf('%.3f', 1) ?? '', 0);
+      $miniocr->startElement("b");
+      $miniocr->startElement("l");
+      $miniocr->startElement("w");
+      $miniocr->writeAttribute("x",
+        $l . ' ' . $t . ' ' . $w . ' ' . $h);
+      $concat_text = '';
+      foreach ($page->xpath('.//ns:TextBlock') as $block) {
+
+        foreach ($block->children() as $line) {
+
+          foreach ($line->children() as $child_name => $child_node) {
+            if ($child_name == 'SP') {
+              $concat_text = $concat_text. ' ';
+            }
+            elseif ($child_name == 'String') {
+              // New OCR Highlight > 0.71 does not like empty <w> tags at all
+              if (strlen(trim($child_node['CONTENT'] ?? "")) > 0) {
+                $concat_text = $concat_text.trim($child_node['CONTENT']). " ";
+
+                // Only assume we have at least one word for <w> tags
+                // Since lines? could end empty?
+                $atleastone_word = TRUE;
+              }
+            }
+          }
+          $concat_text = $concat_text . "&#xD;&#xA;";
+        }
+      }
+      if ($atleastone_word) {
+        $miniocr->text(trim($concat_text, " \t\n\r\0\x0B"));
+      }
+      $miniocr->endElement(); // Ends the single W
+      $miniocr->endElement(); // Ends the single l
+      $miniocr->endElement();// Ends the single b
+      $miniocr->endElement(); // Ends the single p
     }
     $miniocr->endElement();
     $miniocr->endDocument();

--- a/src/Plugin/StrawberryRunnersPostProcessor/SubtitlePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/SubtitlePostProcessor.php
@@ -41,7 +41,9 @@ class SubtitlePostProcessor extends TextPostProcessor {
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['text/vtt'],
+        'mime_type' => 'text/vtt',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',
@@ -103,6 +105,22 @@ class SubtitlePostProcessor extends TextPostProcessor {
       '#default_value' => $this->getConfiguration()['mime_type'],
       '#description' => $this->t('A single Mimetype type or a comma separated list of mimetypes that qualify to be Processed. Leave empty to apply any file'),
     ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
+    ];
+
 
     $element['language_key'] = [
       '#type' => 'textfield',

--- a/src/Plugin/StrawberryRunnersPostProcessor/SystemBinaryPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/SystemBinaryPostProcessor.php
@@ -43,7 +43,9 @@ class SystemBinaryPostProcessor extends StrawberryRunnersPostProcessorPluginBase
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['application/pdf'],
+        'mime_type' => 'application/pdf',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'path' => '',
         'arguments' => '',
         'output_type' => 'json',
@@ -106,6 +108,22 @@ class SystemBinaryPostProcessor extends StrawberryRunnersPostProcessorPluginBase
       '#default_value' => $this->getConfiguration()['mime_type'],
       '#description' => $this->t('A single Mimetype type or a coma separed list of mimetypes that qualify to be Processed. Leave empty to apply any file'),
     ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
+    ];
+
     $element['file_limit_type'] = [
     '#type' => 'select',
       '#title' => $this->t('File Size(s) comparision used to limit this Processor to.'),
@@ -117,6 +135,22 @@ class SystemBinaryPostProcessor extends StrawberryRunnersPostProcessorPluginBase
       '#default_value' => $this->getConfiguration()['file_limit_type'],
       '#description' => $this->t('Select how the file size limit should be evaluated'),
     ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
+    ];
+
 
     $element['file_limit_value_bytes'] = [
       '#type' => 'textfield',

--- a/src/Plugin/StrawberryRunnersPostProcessor/TextPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/TextPostProcessor.php
@@ -38,7 +38,9 @@ class TextPostProcessor extends OcrPostProcessor {
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['application/pdf'],
+        'mime_type' => 'application/pdf',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',
@@ -102,6 +104,22 @@ class TextPostProcessor extends OcrPostProcessor {
       '#default_value' => $this->getConfiguration()['mime_type'],
       '#description' => $this->t('A single Mimetype type or a comma separated list of mimetypes that qualify to be Processed. Leave empty to apply any file'),
     ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
+    ];
+
 
     $element['language_key'] = [
       '#type' => 'textfield',

--- a/src/Plugin/StrawberryRunnersPostProcessor/WaczPagesSequencePostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/WaczPagesSequencePostProcessor.php
@@ -28,7 +28,9 @@ class WaczPagesSequencePostProcessor extends StrawberryRunnersPostProcessorPlugi
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['application/vnd.datapackage+zip'],
+        'mime_type' => 'application/vnd.datapackage+zip',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'output_type' => 'json',
         'output_destination' => ['plugin' => 'plugin'],
         'processor_queue_type' => ['realtime' => 'realtime'],

--- a/src/Plugin/StrawberryRunnersPostProcessor/WarcExtractionPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/WarcExtractionPostProcessor.php
@@ -34,7 +34,9 @@ class WarcExtractionPostProcessor extends StrawberryRunnersPostProcessorPluginBa
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['application/pdf'],
+        'mime_type' => '',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'path' => '',
         'arguments' => '',
         'output_type' => 'json',
@@ -91,6 +93,21 @@ class WarcExtractionPostProcessor extends StrawberryRunnersPostProcessorPluginBa
       '#title' => $this->t('Mimetypes(s) to limit this Processor to.'),
       '#default_value' => $this->getConfiguration()['mime_type'],
       '#description' => $this->t('A single Mimetype type or a coma separed list of mimetypes that qualify to be Processed. Leave empty to apply any file'),
+    ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a coma separed list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Negate Upload JSON Key name(s).'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be negated instead. Means, any upload JSON Key name except the listed ones.'),
+      '#required' => FALSE,
     ];
 
     $element['output_type'] = [

--- a/src/Plugin/StrawberryRunnersPostProcessor/abstractMLPostProcessor.php
+++ b/src/Plugin/StrawberryRunnersPostProcessor/abstractMLPostProcessor.php
@@ -28,7 +28,9 @@ abstract class abstractMLPostProcessor extends StrawberryRunnersPostProcessorPlu
   public function defaultConfiguration() {
     return [
         'source_type' => 'asstructure',
-        'mime_type' => ['image/jpeg'],
+        'mime_type' => 'image/jpeg',
+        'dr_for' => '',
+        'dr_for_negate' => FALSE,
         'output_type' => 'json',
         'output_destination' => 'searchapi',
         'processor_queue_type' => 'background',
@@ -131,6 +133,21 @@ abstract class abstractMLPostProcessor extends StrawberryRunnersPostProcessorPlu
           ':input[name="pluginconfig[source_type]"]' => ['value' => 'asstructure'],
         ],
       ],
+    ];
+
+    $element['dr_for'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('File Upload JSON Key name(s) to limit this Processor to.'),
+      '#default_value' => $this->getConfiguration()['dr_for'],
+      '#description' => $this->t('A single JSON key name or a comma separated list of JSON key names where the files that should qualify were uploaded to (dr:for in an as:filetype structure). Leave empty to apply any file upload key'),
+    ];
+
+    $element['dr_for_negate'] = [
+      '#type' => 'checkbox',
+      '#title' => $this->t('Skip post processing to the above configured "File Upload JSON Key name(s)"'),
+      '#default_value' => (bool) $this->getConfiguration()['dr_for_negate'] ?? FALSE,
+      '#description' => $this->t('If the previous File Upload JSON key name(s) should be skipped instead. Means, files uploaded to any JSON Key name(s) will be processed, except the ones present in above configured "File Upload JSON Key name(s)".'),
+      '#required' => FALSE,
     ];
 
     $element['language_key'] = [

--- a/src/strawberryRunnerUtilityService.php
+++ b/src/strawberryRunnerUtilityService.php
@@ -16,6 +16,7 @@ use Drupal\Core\StreamWrapper\StreamWrapperManagerInterface;
 use Drupal\Core\StringTranslation\TranslationInterface;
 use Drupal\strawberry_runners\Plugin\StrawberryRunnersPostProcessorPluginManager;
 use Drupal\strawberry_runners\Plugin\QueueWorker\AbstractPostProcessorQueueWorker;
+use stdClass;
 
 class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceInterface {
 
@@ -230,15 +231,17 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
                 ) {
                   foreach ($activePlugins as $activePluginId => $config) {
                     // Checks if the flag is set and is an array.
-                    $nopost = (isset($flatvalues["ap:tasks"]["ap:nopost"]) &&
+                    $nopost = [];
+                    $nopost_present = (isset($flatvalues["ap:tasks"]["ap:nopost"]) &&
                       is_array($flatvalues["ap:tasks"]["ap:nopost"]));
 
-                    if ($nopost) {
+                    if ($nopost_present) {
                       if (in_array($activePluginId, $flatvalues["ap:tasks"]["ap:nopost"])) {
                         // if we have an entry like ["ap:tasks"]["ap:nopost"][0] == "pager" we don't run pager
                         // for this ADO. We won't delete existing ones. Just never process.
                         continue;
                       }
+                      $nopost = $flatvalues["ap:tasks"]["ap:nopost"];
                     }
 
                     // Never ever run a processor over its own creation
@@ -246,7 +249,24 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
                       continue;
                     }
 
-                    //@TODO also split $config['ado_type'] so we can check
+                    $valid_file_sources =  explode(',', ($config['dr_for'] ?? ''));
+                    $negate_file_sources =  (bool) ($config['dr_for_negate'] ?? FALSE);
+                    $valid_file_sources = array_map('trim', $valid_file_sources);
+                    $valid_file_sources = array_filter($valid_file_sources);
+                    $skip_bc_file_sources = FALSE;
+                    foreach ($valid_file_sources as $dr_for) {
+                      if (!empty($dr_for) ) {
+                        $skip_bc_file_sources = match($negate_file_sources) {
+                          true  => $asstructure["dr:for"] == $dr_for,
+                          false => $asstructure["dr:for"] != $dr_for,
+                        };
+                      }
+                    }
+
+                    if ($skip_bc_file_sources) {
+                      continue;
+                    }
+
                     $valid_ado_type = explode(',', $config['ado_type']);
                     $valid_ado_type = array_map('trim', $valid_ado_type);
                     if (empty($config['ado_type'])
@@ -267,8 +287,8 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
                       ) {
                         // Now that mimetypes, if any, were evaluated,
                         // We can check if File Size limit applies
-                        if ($config['file_limit_type'] && in_array($config['file_limit_type'], ['<=', '>='])) {
-                          if ($config['file_limit_value_bytes']) {
+                        if (isset($config['file_limit_type']) && in_array($config['file_limit_type'], ['<=', '>='])) {
+                          if (isset($config['file_limit_value_bytes'])) {
                             $bytes = Bytes::validate($config['file_limit_value_bytes']) ? self::bytes_string_to_number($config['file_limit_value_bytes']) : NULL;
                             $skip = TRUE;
                             if ($bytes) {
@@ -297,7 +317,9 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
 
                         $config['processor_queue_type'] = $config['processor_queue_type'] ?? 'realtime';
                         $queue_name = AbstractPostProcessorQueueWorker::QUEUES[$config['processor_queue_type']] ?? AbstractPostProcessorQueueWorker::QUEUES['realtime'];
-                        $data = new \stdClass();
+                        $data = new stdClass();
+                        $data->sbf_type = $sbf_type;
+                        $data->nopost = $nopost;
                         $data->fid = $asstructure['dr:fid'];
                         $data->nid = $entity->id();
                         $data->asstructure_uniqueid = $uniqueid;
@@ -313,8 +335,7 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
                         // of locally generated files from $data->fid
                         $data->sbr_cleanedup_before = FALSE;
                         // Get the configured Language from descriptive metadata
-                        if (isset($config['language_key'])
-                          && !empty($config['language_key'])
+                        if (!empty($config['language_key'])
                           && isset($flatvalues[$config['language_key']])
                         ) {
                           $data->lang = is_array(
@@ -359,7 +380,7 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
                         // Since the destination Queue can be a modal thing
                         // And really what defines is the type of worker we want
                         // But all at the end will eventually feed the ::run() method
-                        // We want to make this a full blown service.
+                        // We want to make this a full-blown service.
                         $success = $this->queueFactory->get(
                           $queue_name, TRUE
                         )->createItem($data);
@@ -380,15 +401,17 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
             if (!empty($metadata_from_json)) {
               foreach ($activePlugins as $activePluginId => $config) {
                 // Checks if the flag is set and is an array.
-                $nopost = (isset($flatvalues["ap:tasks"]["ap:nopost"]) &&
+                $nopost = [];
+                $nopost_present = (isset($flatvalues["ap:tasks"]["ap:nopost"]) &&
                   is_array($flatvalues["ap:tasks"]["ap:nopost"]));
 
-                if ($nopost) {
+                if ($nopost_present) {
                   if (in_array($activePluginId, $flatvalues["ap:tasks"]["ap:nopost"])) {
                     // if we have an entry like ["ap:tasks"]["ap:nopost"][0] == "pager" we don't run pager
-                    // for this ADO. We won't delete existing ones. Just never process.
+                    // for this ADO. We won't delete existing ones. Just never process.=
                     continue;
                   }
+                  $nopost = $flatvalues["ap:tasks"]["ap:nopost"];
                 }
                 // @TODO how to avoid running on metadata generated by a processor?
                 // We should limit where that metadata goes. Should never be the same ADO?
@@ -401,7 +424,9 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
                 ) {
                   $config['processor_queue_type'] = $config['processor_queue_type'] ?? 'realtime';
                   $queue_name = AbstractPostProcessorQueueWorker::QUEUES[$config['processor_queue_type']] ?? AbstractPostProcessorQueueWorker::QUEUES['realtime'];
-                  $data = new \stdClass();
+                  $data = new stdClass();
+                  $data->sbf_type = $sbf_type;
+                  $data->nopost = $nopost;
                   $data->fid = NULL;
                   $data->nid = $entity->id();
                   $data->nuuid = $entity->uuid();
@@ -411,8 +436,7 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
                   // by saying. This was cleaned up before.
                   $data->sbr_cleanedup_before = TRUE;
                   // Get the configured Language from descriptive metadata
-                  if (isset($config['language_key'])
-                    && !empty($config['language_key'])
+                  if (!empty($config['language_key'])
                     && isset($flatvalues[$config['language_key']])
                   ) {
                     $data->lang = is_array(
@@ -524,4 +548,92 @@ class strawberryRunnerUtilityService implements strawberryRunnerUtilityServiceIn
     }
   }
 
+
+  public function canInvokeSingleProcessor($activePluginId, array $config, stdClass $data):bool {
+    $nopost_present = is_array($data->nopost) && !empty($nopost);
+    if ($nopost_present) {
+      if (in_array($activePluginId, $data->nopost)) {
+        // if we have an entry like ["ap:tasks"]["ap:nopost"][0] == "ocr" we don't run pager
+        // for this ADO. We won't delete existing ones. Just never process.
+        return FALSE;
+      }
+    }
+
+    // Never ever run a processor over its own creation
+    // @TODO: We could re-think this and allow it to run of $data->force == true?
+    if (isset($data->metadata) && ($data->metadata["dr:for"] ?? '') == 'flv:' . $activePluginId) {
+      return FALSE;
+    }
+    $valid_file_sources = explode(',', ($config['dr_for'] ?? ''));
+    $negate_file_sources = (bool) ($config['dr_for_negate'] ?? FALSE);
+    $valid_file_sources = array_map('trim', $valid_file_sources);
+    $valid_file_sources = array_filter($valid_file_sources);
+    $skip_bc_file_sources = FALSE;
+    foreach ($valid_file_sources as $dr_for) {
+      if (isset($data->metadata["dr:for"]) && !empty($dr_for)) {
+        $skip_bc_file_sources = match ($negate_file_sources) {
+          TRUE => $data->metadata["dr:for"] == $dr_for,
+          FALSE => $data->metadata["dr:for"] != $dr_for,
+        };
+      }
+    }
+
+    if ($skip_bc_file_sources) {
+      return FALSE;
+    }
+
+    $valid_ado_type = explode(',', $config['ado_type']);
+    $valid_ado_type = array_map('trim', $valid_ado_type);
+    if (empty($config['ado_type'])
+      || count(
+        array_intersect($valid_ado_type, $data->sbf_type ?? [])
+      ) > 0
+    ) {
+      $valid_mimes = explode(',', $config['mime_type']);
+      $valid_mimes = array_filter(
+        array_map('trim', $valid_mimes)
+      );
+      if ($config['source_type'] == 'json' || isset($data->metadata["dr:mimetype"]) && empty($data->metadata['flv:' . $activePluginId]) || ($data->force ?? FALSE) && empty($valid_mimes)
+        || (isset($data->metadata["dr:mimetype"])
+          && in_array(
+            $data->metadata["dr:mimetype"], $valid_mimes
+          ))
+      ) {
+        if (is_array($data->metadata ?? FALSE) && isset($config['file_limit_type']) && in_array($config['file_limit_type'], ['<=', '>='])) {
+          if (!empty($config['file_limit_value_bytes'])) {
+            $bytes = Bytes::validate($config['file_limit_value_bytes']) ? self::bytes_string_to_number($config['file_limit_value_bytes']) : NULL;
+            $skip = TRUE;
+            if ($bytes) {
+              switch($config['file_limit_type']) {
+                case '<=':
+                  // Could be missing?
+                  if (isset($data->metadata['dr:filesize']) &&  (float) $data->metadata['dr:filesize'] <= (float) $bytes) {
+                    $skip = FALSE;
+                  }
+                  break;
+                case '>=':
+                  // Could be missing?
+                  if (isset($data->metadata['dr:filesize']) &&  (float) $data->metadata['dr:filesize'] >= (float) $bytes) {
+                    $skip = FALSE;
+                  }
+                  break;
+                default:
+                  break;
+              }
+            }
+            if ($skip) {
+              return FALSE;
+            }
+          }
+        }
+        return TRUE;
+      }
+      else {
+        return FALSE;
+      }
+    }
+    else {
+      return FALSE;
+    }
+  }
 }

--- a/src/strawberryRunnerUtilityServiceInterface.php
+++ b/src/strawberryRunnerUtilityServiceInterface.php
@@ -35,4 +35,15 @@ interface strawberryRunnerUtilityServiceInterface {
    */
   public function getActivePluginConfigs($onlyRoot = TRUE):array;
 
+  /**
+   * Checks if a particular Processor, given a Child Data structure should run
+   *
+   * @param $activePluginId
+   * @param $data
+   * @param $config
+   *
+   * @return bool
+   */
+  public function canInvokeSingleProcessor($activePluginId, array $config, \stdClass $data):bool;
+
 }


### PR DESCRIPTION
See #123 and #122 

This also adds (might need config changes) chained processor validation against configured limits.

Previously only Root Processors would be strictly validated against mime type/ado type etc. Now every step/deep down gets a new method to ensure one can have a spanning (Root) Processor like pager, invoke two OCRs, but each one can act on different ADOs/settings, etc.


Fixes silly 5 year old thing? (gosh) where some defaults were set as arrays, even if the saved value/config was always a string.
+ improves (not perfect?) default schema